### PR TITLE
handle float32 input correctly

### DIFF
--- a/dtcwt/transform1d.py
+++ b/dtcwt/transform1d.py
@@ -5,7 +5,7 @@ from six.moves import xrange
 
 from dtcwt import biort as _biort, qshift as _qshift
 from dtcwt.defaults import DEFAULT_BIORT, DEFAULT_QSHIFT
-from dtcwt.lowlevel import colfilter, coldfilt, colifilt, as_column_vector
+from dtcwt.lowlevel import colfilter, coldfilt, colifilt, as_column_vector, asfarray
 
 def dtwavexfm(X, nlevels=3, biort=DEFAULT_BIORT, qshift=DEFAULT_QSHIFT, include_scale=False):
     """Perform a *n*-level DTCWT decompostion on a 1D column vector *X* (or on
@@ -38,7 +38,7 @@ def dtwavexfm(X, nlevels=3, biort=DEFAULT_BIORT, qshift=DEFAULT_QSHIFT, include_
 
     """
     # Need this because colfilter and friends assumes input is 2d
-    X = np.asfarray(X)
+    X = asfarray(X)
     if len(X.shape) == 1:
        X = np.atleast_2d(X).T
 
@@ -54,7 +54,7 @@ def dtwavexfm(X, nlevels=3, biort=DEFAULT_BIORT, qshift=DEFAULT_QSHIFT, include_
     except TypeError:
         h0a, h0b, g0a, g0b, h1a, h1b, g1a, g1b = qshift
 
-    L = np.asarray(X.shape)
+    L = np.asanyarray(X.shape)
 
     # ensure that X is an even length, thus enabling it to be extended if needs be.
     if X.shape[0] % 2 != 0:
@@ -162,7 +162,7 @@ def dtwaveifm(Yl, Yh, biort=DEFAULT_BIORT, qshift=DEFAULT_QSHIFT, gain_mask=None
        if Lo.shape[0] != 2*Yh[level-1].shape[0]:  # If Lo is not the same length as the next Yh => t1 was extended.
           Lo = Lo[1:-1,...]                       # Therefore we have to clip Lo so it is the same height as the next Yh.
 
-       if np.any(np.asarray(Lo.shape) != np.asarray(Yh[level-1].shape * np.array((2,1)))):
+       if np.any(np.asanyarray(Lo.shape) != np.asanyarray(Yh[level-1].shape * np.array((2,1)))):
           raise ValueError('Yh sizes are not valid for DTWAVEIFM')
        
        level -= 1
@@ -187,7 +187,7 @@ def c2q1d(x):
 
     """
     a, b = x.shape
-    z = np.zeros((a*2, b))
+    z = np.zeros((a*2, b), dtype=x.real.dtype)
     z[::2, :] = np.real(x)
     z[1::2, :] = np.imag(x)
 

--- a/dtcwt/transform2d.py
+++ b/dtcwt/transform2d.py
@@ -5,7 +5,7 @@ from six.moves import xrange
 
 from dtcwt import biort as _biort, qshift as _qshift
 from dtcwt.defaults import DEFAULT_BIORT, DEFAULT_QSHIFT
-from dtcwt.lowlevel import colfilter, coldfilt, colifilt, appropriate_complex_type_for
+from dtcwt.lowlevel import colfilter, coldfilt, colifilt, appropriate_complex_type_for, asfarray
 
 def dtwavexfm2(X, nlevels=3, biort=DEFAULT_BIORT, qshift=DEFAULT_QSHIFT, include_scale=False):
     """Perform a *n*-level DTCWT-2D decompostion on a 2D matrix *X*.
@@ -36,7 +36,7 @@ def dtwavexfm2(X, nlevels=3, biort=DEFAULT_BIORT, qshift=DEFAULT_QSHIFT, include
     .. codeauthor:: Cian Shaffrey, Cambridge University, Sept 2001
 
     """
-    X = np.atleast_2d(np.asfarray(X))
+    X = np.atleast_2d(asfarray(X))
 
     # Try to load coefficients if biort is a string parameter
     try:
@@ -289,7 +289,7 @@ def c2q(w,gain):
 
     """
 
-    x = np.zeros((w.shape[0] << 1, w.shape[1] << 1))
+    x = np.zeros((w.shape[0] << 1, w.shape[1] << 1), dtype=w.real.dtype)
 
     sc = np.sqrt(0.5) * gain
     P = w[:,:,0]*sc[0] + w[:,:,1]*sc[1]

--- a/dtcwt/transform3d.py
+++ b/dtcwt/transform3d.py
@@ -5,7 +5,7 @@ from six.moves import xrange
 
 from dtcwt import biort as _biort, qshift as _qshift
 from dtcwt.defaults import DEFAULT_BIORT, DEFAULT_QSHIFT
-from dtcwt.lowlevel import colfilter, coldfilt, colifilt
+from dtcwt.lowlevel import colfilter, coldfilt, colifilt, asfarray
 
 def dtwavexfm3(X, nlevels=3, biort=DEFAULT_BIORT, qshift=DEFAULT_QSHIFT, ext_mode=4):
     """Perform a *n*-level DTCWT-3D decompostion on a 3D matrix *X*.
@@ -49,7 +49,7 @@ def dtwavexfm3(X, nlevels=3, biort=DEFAULT_BIORT, qshift=DEFAULT_QSHIFT, ext_mod
     .. codeauthor:: Nick Kingsbury, Cambridge University, July 1999.
 
     """
-    X = np.atleast_3d(np.asfarray(X))
+    X = np.atleast_3d(asfarray(X))
 
     # Try to load coefficients if biort is a string parameter
     try:
@@ -155,7 +155,7 @@ def _level1_xfm(X, h0o, h1o, ext_mode):
         raise ValueError('Input shape should be a multiple of 4 in each direction when ext_mode == 8')
 
     # Create work area
-    work_shape = np.asarray(X.shape) * 2
+    work_shape = np.asanyarray(X.shape) * 2
 
     # We need one extra row per octant if filter length is even
     if h0o.shape[0] % 2 == 0:
@@ -246,7 +246,7 @@ def _level2_xfm(X, h0a, h0b, h1a, h1b, ext_mode):
             X = np.concatenate((X[:,:,(0,0)], X, X[:,:,(-1,-1)]), 2)
 
     # Create work area
-    work_shape = np.asarray(X.shape)
+    work_shape = np.asanyarray(X.shape)
     work = np.zeros(work_shape, dtype=X.dtype)
 
     # Form some useful slices
@@ -298,10 +298,10 @@ def _level1_ifm(Yl, Yh, g0o, g1o):
 
     """
     # Create work area
-    work = np.zeros(np.asarray(Yl.shape) * 2, dtype=Yl.dtype)
+    work = np.zeros(np.asanyarray(Yl.shape) * 2, dtype=Yl.dtype)
 
     # Work out shape of output
-    Xshape = np.asarray(work.shape) >> 1
+    Xshape = np.asanyarray(work.shape) >> 1
     if g0o.shape[0] % 2 == 0:
         # if we have an even length filter, we need to shrink the output by 1
         # to compensate for the addition of an extra row/column/slice in 
@@ -355,7 +355,7 @@ def _level2_ifm(Yl, Yh, g0a, g0b, g1a, g1b, ext_mode, prev_level_size):
 
     """
     # Create work area
-    work = np.zeros(np.asarray(Yl.shape)*2, dtype=Yl.dtype)
+    work = np.zeros(np.asanyarray(Yl.shape)*2, dtype=Yl.dtype)
 
     # Form some useful slices
     s0a = slice(None, work.shape[0] >> 1)
@@ -507,7 +507,7 @@ def c2cube(z):
     rr, ri = r.real, r.imag
     sr, si = s.real, s.imag
 
-    y = np.zeros(np.asarray(z.shape[:3])*2, dtype=z.real.dtype)
+    y = np.zeros(np.asanyarray(z.shape[:3])*2, dtype=z.real.dtype)
 
     y[1::2, 1::2, 1::2] = ( pr+qr+rr+sr)
     y[0::2, 0::2, 1::2] = (-pr-qr+rr+sr)

--- a/tests/testifm1.py
+++ b/tests/testifm1.py
@@ -23,4 +23,13 @@ def test_reconstruct_2d():
     vec_recon = dtwaveifm(Yl, Yh)
     assert np.all(np.abs(vec_recon - vec) < TOLERANCE)
 
+def test_float32_input():
+    # Check that an float32 input is correctly output as float32
+    Yl, Yh = dtwavexfm(np.array([1, 2, 3, 4]).astype(np.float32))
+    assert np.issubsctype(Yl.dtype, np.float32)
+    assert np.all(list(np.issubsctype(x.dtype, np.complex64) for x in Yh))
+
+    recon = dtwaveifm(Yl, Yh)
+    assert np.issubsctype(recon.dtype, np.float32)
+
 # vim:sw=4:sts=4:et

--- a/tests/testifm2.py
+++ b/tests/testifm2.py
@@ -39,5 +39,14 @@ def test_reconstruct_custom_filter():
     lena_recon = dtwaveifm2(Yl, Yh, biort('legall'), qshift('qshift_06'))
     assert np.all(np.abs(lena_recon - lena) < TOLERANCE)
 
+def test_float32_input():
+    # Check that an float32 input is correctly output as float32
+    Yl, Yh = dtwavexfm2(lena.astype(np.float32))
+    assert np.issubsctype(Yl.dtype, np.float32)
+    assert np.all(list(np.issubsctype(x.dtype, np.complex64) for x in Yh))
+
+    lena_recon = dtwaveifm2(Yl, Yh)
+    assert np.issubsctype(lena_recon.dtype, np.float32)
+
 
 # vim:sw=4:sts=4:et

--- a/tests/testxfm1.py
+++ b/tests/testxfm1.py
@@ -74,4 +74,10 @@ def test_integer_perfect_recon():
     B = dtwaveifm(Yl, Yh)
     assert np.max(np.abs(A-B)) < 1e-12
 
+def test_float32_input():
+    # Check that an float32 input is correctly output as float32
+    Yl, Yh = dtwavexfm(np.array([1,2,3,4]).astype(np.float32))
+    assert np.issubsctype(Yl.dtype, np.float32)
+    assert np.all(list(np.issubsctype(x.dtype, np.complex64) for x in Yh))
+
 # vim:sw=4:sts=4:et

--- a/tests/testxfm2.py
+++ b/tests/testxfm2.py
@@ -77,4 +77,10 @@ def test_integer_perfect_recon():
     B = dtwaveifm2(Yl, Yh)
     assert np.max(np.abs(A-B)) < 1e-5
 
+def test_float32_input():
+    # Check that an float32 input is correctly output as float32
+    Yl, Yh = dtwavexfm2(lena.astype(np.float32))
+    assert np.issubsctype(Yl.dtype, np.float32)
+    assert np.all(list(np.issubsctype(x.dtype, np.complex64) for x in Yh))
+
 # vim:sw=4:sts=4:et

--- a/tests/testxfm3.py
+++ b/tests/testxfm3.py
@@ -56,7 +56,6 @@ def test_simple_level_1_recon_haar():
     Yl, Yh = dtwavexfm3(ellipsoid, 1, biort=haar)
     ellipsoid_recon = dtwaveifm3(Yl, Yh, biort=haar)
     assert ellipsoid.size == ellipsoid_recon.size
-    print(np.max(np.abs(ellipsoid - ellipsoid_recon)))
     assert np.max(np.abs(ellipsoid - ellipsoid_recon)) < TOLERANCE
 
 def test_simple_level_2_xfm():
@@ -135,5 +134,20 @@ def test_integer_perfect_recon():
     Yl, Yh = dtwavexfm3(A)
     B = dtwaveifm3(Yl, Yh)
     assert np.max(np.abs(A-B)) < 1e-12
+
+def test_float32_input():
+    # Check that an float32 input is correctly output as float32
+    Yl, Yh = dtwavexfm3(ellipsoid.astype(np.float32))
+    assert np.issubsctype(Yl.dtype, np.float32)
+    assert np.all(list(np.issubsctype(x.dtype, np.complex64) for x in Yh))
+
+def test_float32_recon():
+    # Check that an float32 input is correctly output as float32
+    Yl, Yh = dtwavexfm3(ellipsoid.astype(np.float32))
+    assert np.issubsctype(Yl.dtype, np.float32)
+    assert np.all(list(np.issubsctype(x.dtype, np.complex64) for x in Yh))
+
+    recon = dtwaveifm3(Yl, Yh)
+    assert np.issubsctype(recon.dtype, np.float32)
 
 # vim:sw=4:sts=4:et


### PR DESCRIPTION
When presented with a float32 input, the library should perform a 32-bit
single precision transform and not a full double-precision one.  Add test
cases for float32 and make the transform library pass.
