### PR TITLE
testxfm3: replace np.meshgrid with np.mgrid

### DIFF
--- a/tests/testxfm3.py
+++ b/tests/testxfm3.py
@@ -12,8 +12,8 @@ TOLERANCE = 1e-12
 def setup():
     global ellipsoid
 
-    grid = np.arange(-(GRID_SIZE>>1), (GRID_SIZE>>1))
-    X, Y, Z = np.meshgrid(grid, grid, grid)
+    grid = slice(-(GRID_SIZE>>1), (GRID_SIZE>>1))
+    X, Y, Z = np.mgrid[grid,grid,grid]
 
     Y *= 1.2
     Z *= 1.4


### PR DESCRIPTION
Replace the usage of meshgrid with an analogous mgrid indexing solution. This
is a little more ugly but it is compatible with older numpys.

Closes #20.
