### PR TITLE
workaround numpy.mean() version without keepdims

### DIFF
--- a/matlab/verif_m_to_npz.py
+++ b/matlab/verif_m_to_npz.py
@@ -4,17 +4,30 @@ import numpy as np
 from scipy.io import loadmat
 from numpy import savez
 
+def _mean(a, axis=None, *args, **kwargs):
+    """Equivalent to numpy.mean except that the axis along which the mean is taken is not removed."""
+
+    rv = np.mean(a, axis=axis, *args, **kwargs)
+
+    if axis is not None:
+        rv = np.expand_dims(rv, axis)
+
+    return rv
+
 def summarise_mat(M, apron=8):
     """HACK to provide a 'summary' matrix consisting of the corners of the
-    matrix and summed versions of the sub matrices."""
+    matrix and summed versions of the sub matrices.
+    
+    N.B. Keep this in sync with matlab/verif_m_to_npz.py.
 
+    """
     centre = M[apron:-apron,apron:-apron,...]
-    centre_sum = np.mean(np.mean(centre, axis=0, keepdims=True), axis=1, keepdims=True)
+    centre_sum = _mean(_mean(centre, axis=0), axis=1)
 
     return np.vstack((
-        np.hstack((M[:apron,:apron,...], np.mean(M[:apron,apron:-apron,...], axis=1, keepdims=True), M[:apron,-apron:,...])),
-        np.hstack((np.mean(M[apron:-apron,:apron,...], axis=0, keepdims=True), centre_sum, np.mean(M[apron:-apron,-apron:,...], axis=0, keepdims=True))),
-        np.hstack((M[-apron:,:apron,...], np.mean(M[-apron:,apron:-apron,...], axis=1, keepdims=True), M[-apron:,-apron:,...])),
+        np.hstack((M[:apron,:apron,...], _mean(M[:apron,apron:-apron,...], axis=1), M[:apron,-apron:,...])),
+        np.hstack((_mean(M[apron:-apron,:apron,...], axis=0), centre_sum, _mean(M[apron:-apron,-apron:,...], axis=0))),
+        np.hstack((M[-apron:,:apron,...], _mean(M[-apron:,apron:-apron,...], axis=1), M[-apron:,-apron:,...])),
     ))
 
 verif = loadmat('verification.mat')

--- a/tests/util.py
+++ b/tests/util.py
@@ -11,6 +11,16 @@ def assert_almost_equal(a, b, tolerance=TOLERANCE):
             'Arrays differ by a maximum of {0} which is greater than the tolerance of {1}'.
             format(md, tolerance))
 
+def _mean(a, axis=None, *args, **kwargs):
+    """Equivalent to numpy.mean except that the axis along which the mean is taken is not removed."""
+
+    rv = np.mean(a, axis=axis, *args, **kwargs)
+
+    if axis is not None:
+        rv = np.expand_dims(rv, axis)
+
+    return rv
+
 def summarise_mat(M, apron=8):
     """HACK to provide a 'summary' matrix consisting of the corners of the
     matrix and summed versions of the sub matrices.
@@ -19,10 +29,10 @@ def summarise_mat(M, apron=8):
 
     """
     centre = M[apron:-apron,apron:-apron,...]
-    centre_sum = np.mean(np.mean(centre, axis=0, keepdims=True), axis=1, keepdims=True)
+    centre_sum = _mean(_mean(centre, axis=0), axis=1)
 
     return np.vstack((
-        np.hstack((M[:apron,:apron,...], np.mean(M[:apron,apron:-apron,...], axis=1, keepdims=True), M[:apron,-apron:,...])),
-        np.hstack((np.mean(M[apron:-apron,:apron,...], axis=0, keepdims=True), centre_sum, np.mean(M[apron:-apron,-apron:,...], axis=0, keepdims=True))),
-        np.hstack((M[-apron:,:apron,...], np.mean(M[-apron:,apron:-apron,...], axis=1, keepdims=True), M[-apron:,-apron:,...])),
+        np.hstack((M[:apron,:apron,...], _mean(M[:apron,apron:-apron,...], axis=1), M[:apron,-apron:,...])),
+        np.hstack((_mean(M[apron:-apron,:apron,...], axis=0), centre_sum, _mean(M[apron:-apron,-apron:,...], axis=0))),
+        np.hstack((M[-apron:,:apron,...], _mean(M[-apron:,apron:-apron,...], axis=1), M[-apron:,-apron:,...])),
     ))


### PR DESCRIPTION
This is a workaround for older numpys whose mean() function does not have the
keepdims keyword option.

Closes #26.
