### PR TITLE
workaround enabling MathJax under ReadTheDocs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -170,7 +170,7 @@ html_static_path = ['_static']
 htmlhelp_basename = 'dtcwtdoc'
 
 # On read the docs we need to use a different CDN URL for MathJax which loads
-# over HTTPS or HTTP depending on how the page loads.
+# over HTTPS.
 if os.environ.get('READTHEDOCS', None) == 'True':
     mathjax_path = 'https://c328740.ssl.cf1.rackcdn.com/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'
 


### PR DESCRIPTION
RTD serves all content over HTTPS. The default Sphinx MathJax URL tries to
fetch JavaScript over HTTP which doesn't wokr on modern Chrome and is soon to
not work under Firefox.

This pull-request implements a workaround by explicitly specifying a HTTPS URL
for MathJax when compiling under RTD.

It may be worth enabling the HTTPS URL by default if the behaviour bite in
other ways.
