### PR TITLE
MANIFEST.in: reduce size of PyPi source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-include tests/*.py
-include tests/*.npz
-
+exclude tests/
+exclude docs/
+exclude .*


### PR DESCRIPTION
I don't think people use the PyPi bundle to actually run tests or compile
documentation and so experiment with removing both from the MANIFEST.in file.
This reduces the size of the download from ~2MB (which already lacked much of
the documentation) down to ~200KB.

Certainly the common case of "pip install dtcwt" will build neither the 
documentation or run the test suite. Although perhaps it should?
