### PR TITLE
travis: add wheel support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ env:
     - PIP_SPECIFIER=.[docs]
     - PIP_SPECIFIER=.[opencl,docs]
 install:
-    - pip install numpy
-    - pip install coveralls
-    - pip install -e $PIP_SPECIFIER
+    - pip install --upgrade pip setuptools  # Upgrade pip and setuptools to get ones with `wheel` support
+    - pip install --find-links http://wheels.astropy.org/ --find-links http://wheels2.astropy.org/ --use-wheel --use-mirrors numpy coveralls
+    - pip install --find-links http://wheels.astropy.org/ --find-links http://wheels2.astropy.org/ --use-wheel --use-mirrors -e $PIP_SPECIFIER
 script:
     - python setup.py nosetests
     - python scripts/benchmark_opencl.py


### PR DESCRIPTION
Add wheel support for pip which should speed up installing packages with 
lengthy compiles such as numpy.
