### PR TITLE
Fix "wheel-ised" build on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - PIP_SPECIFIER=.[opencl,docs]
 install:
     - pip install --upgrade pip setuptools  # Upgrade pip and setuptools to get ones with `wheel` support
+    - pip install --no-use-wheel pytools # Work around broken pytools wheel on Py3
     - pip install --find-links http://wheels.astropy.org/ --find-links http://wheels2.astropy.org/ --use-wheel numpy matplotlib ipython
     - pip install -e $PIP_SPECIFIER
 script:


### PR DESCRIPTION
The wheel-based builds on travis have been failing. This is mostly my fault for merging into master too hastily. Whereas some wheel packages are very useful for speeding builds (notably numpy), some are broken (notably pytools). The .travis.yml resulting from these changes is a bit mucky but should work for the foreseeable future.
