### PR TITLE
move version to one place only

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,8 +21,10 @@ setup_cfg.read(os.path.join(os.path.dirname(__file__), '..', 'setup.cfg'))
 
 # Load some data from setup.cfg
 project = setup_cfg.get('metadata', 'name')
-version = setup_cfg.get('metadata', 'version')
-release = setup_cfg.get('metadata', 'version')
+
+# Get the version straight from dtcwt
+import dtcwt
+version = release = dtcwt.__version__
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/dtcwt/__init__.py
+++ b/dtcwt/__init__.py
@@ -1,10 +1,9 @@
 import os
 import sys
 
-import dtcwt.numpy
-import dtcwt.opencl
-
 __all__ = [
+    '__version__',
+
     'Transform1d',
     'Transform2d',
     'Transform3d',
@@ -15,6 +14,11 @@ __all__ = [
     'pop_backend',
     'preserve_backend_stack',
 ]
+
+from dtcwt._version import __version__
+
+import dtcwt.numpy
+import dtcwt.opencl
 
 # An array of dictionaries. Each dictionary stores the top-level module
 # variables for that backend.
@@ -55,7 +59,7 @@ class _BackendGuard(object):
         # passed to throw(), because __exit__() must not raise
         # an exception unless __exit__() itself failed.  But
         # throw() has to raise the exception to signal
-        # propagation, so this fixes the impedance mismatch 
+        # propagation, so this fixes the impedance mismatch
         # between the throw() protocol and the __exit__()
         # protocol.
         #

--- a/dtcwt/_version.py
+++ b/dtcwt/_version.py
@@ -1,0 +1,2 @@
+# IMPORTANT: before release, remove the 'devN' tag from the release name
+__version__ = '0.10.0dev1'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,5 @@
 [metadata]
 name = dtcwt
-# IMPORTANT: before release, remove the 'devN' tag from the release name
-version = 0.10.0dev1
 
 [build_sphinx]
 source-dir = docs/

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
 import os
+import re
+
 from setuptools import setup, find_packages
 
 # Utility function to read the README file.
@@ -8,9 +10,13 @@ from setuptools import setup, find_packages
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
+# Read metadata from version file
+metadata_file = open(os.path.join(os.path.dirname(__file__), 'dtcwt', '_version.py')).read()
+metadata = dict(re.findall("__([a-z]+)__ = '([^']+)'", metadata_file))
+
 setup(
     name = 'dtcwt',
-    version = '0.10.0dev1',
+    version = metadata['version'],
     author = "Rich Wareham",
     author_email = "rich.dtcwt@richwareham.com",
     description = ("A port of the Dual-Tree Complex Wavelet Transform MATLAB toolbox."),


### PR DESCRIPTION
Previously the version was a) specified in two places and b) not retrievable
from the dtcwt module at runtime. Move the version string to a single source
of truth to fix both of these.
