### PR TITLE
ensure preserve_backend_stack() preserves backend name

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,8 @@ Changes
 
 * Add queue parameter to low-level OpenCL ``colifilt`` and ``coldfilt`` functions.
 * Significantly increase speed of ``dtcwt.registration.estimatereg`` function.
+* Fix bug whereby ``dtcwt.backend_name`` was not restored when using
+  ``preserve_backend_stack``.
 
 0.9.1
 '''''

--- a/dtcwt/__init__.py
+++ b/dtcwt/__init__.py
@@ -48,6 +48,7 @@ def _update_from_current_backend():
 
 class _BackendGuard(object):
     def __init__(self, stack):
+        # Explicitly copy the stack
         self._stack = list(stack)
 
     def __enter__(self):
@@ -55,6 +56,7 @@ class _BackendGuard(object):
 
     def __exit__(self, exc_type, exc_value, exc_tb):
         dtcwt._BACKEND_STACK = self._stack
+        _update_from_current_backend()
         # only re-raise if it's *not* the exception that was
         # passed to throw(), because __exit__() must not raise
         # an exception unless __exit__() itself failed.  But

--- a/tests/testswitchbackends.py
+++ b/tests/testswitchbackends.py
@@ -80,11 +80,15 @@ def test_backend_with_guard_and_exception():
     correctly propagated.
 
     """
-    assert len(dtcwt._BACKEND_STACK) == 1
+    dtcwt.push_backend('numpy')
+    assert len(dtcwt._BACKEND_STACK) == 2
+    assert dtcwt.backend_name == 'numpy'
     def tst():
         with dtcwt.preserve_backend_stack():
-            dtcwt.push_backend('numpy')
-            assert len(dtcwt._BACKEND_STACK) == 2
+            dtcwt.push_backend('opencl')
+            assert dtcwt.backend_name == 'opencl'
+            assert len(dtcwt._BACKEND_STACK) == 3
             raise RuntimeError('test error')
     assert_raises(RuntimeError, tst)
-    assert len(dtcwt._BACKEND_STACK) == 1
+    assert dtcwt.backend_name == 'numpy'
+    assert len(dtcwt._BACKEND_STACK) == 2


### PR DESCRIPTION
The backend name was incorrectly being modified outside of the with clause
when using preserve_backend_stack().
