### PR TITLE
docs: allow reproducible/deterministic builds

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,10 @@ project = setup_cfg.get('metadata', 'name')
 import dtcwt
 version = release = dtcwt.__version__
 
+# Ensure a deterministic build by setting the random seed
+import numpy
+numpy.random.seed(0)
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.


### PR DESCRIPTION
Based the patch in [1], explicitly set the random seed used by numpy to make
sure that the documentation builds are reproducible.

[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=794005