### PR TITLE
remove references to nose

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,8 @@ Python project::
 significant modification to the library.) A test suite is provided so that you
 may verify the code works on your system::
 
-    $ python setup.py nosetests
+    $ pip install -r tests/requirements.txt
+    $ py.test
 
 This will also write test-coverage information to the ``cover/`` directory.
 

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -32,7 +32,8 @@ may verify the code works on your system:
 
 .. code-block:: console
 
-    $ python setup.py nosetests
+    $ pip install -r tests/requirements.txt
+    $ py.test
 
 This will also write test-coverage information to the ``cover/`` directory.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,8 +5,3 @@ name = dtcwt
 source-dir = docs/
 build-dir  = build/docs
 all_files  = 1
-
-[nosetests]
-with-coverage = 1
-cover-package = dtcwt
-cover-html = 1

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,6 @@ setup(
         'dtcwt': ['data/*.npz',],
     },
 
-    setup_requires=[ 'nose>=1.0', ],
-
     install_requires=[ 'numpy', 'six', ],
 
     extras_require={


### PR DESCRIPTION
We no longer use nose for running unit tests. Remove references to it.