### PR TITLE
fix coverage reporting

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,0 @@
-# Workaround for nosetests overriding coverage output
-# See: https://github.com/coagulant/coveralls-python#nosetests
-[report]
-omit =
-    */python?.?/*
-    */site-packages/nose/*
-    tests/*

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,5 @@
 # Testing-specific packages
 pytest
+pytest-capturelog
+pytest-cov
 coverage

--- a/tox.ini
+++ b/tox.ini
@@ -8,5 +8,5 @@ commands=
     # We can't list these in deps since pyopencl moans if numpy is not
     # fully installed at pip-install time.
     py{27,34}-opencl: pip install -rtests/opencl-requirements.txt
-    py.test {posargs}
+    py.test --cov={envsitepackagesdir}/dtcwt --cov-report=term {posargs}
 sitepackages=True


### PR DESCRIPTION
Add pytest-cov plugin to enable coverage reporting and remove old nose-specific
coverage information.