### PR TITLE
tox: remove use of sitepackages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache:
 before_install:
     - sudo apt-get update -qq
     - sudo apt-get install -y fglrx opencl-headers
-    - sudo apt-get install -y python-numpy python3-numpy
 env:
     - TOX_ENV=py34
     - TOX_ENV=py27

--- a/tox.ini
+++ b/tox.ini
@@ -9,4 +9,3 @@ commands=
     # fully installed at pip-install time.
     py{27,34}-opencl: pip install -rtests/opencl-requirements.txt
     py.test {posargs}
-sitepackages=True


### PR DESCRIPTION
sitepackages was used as an attempt to work around pyopencl testing for numpy
itself rather than using setuptools' support. This should now be unnecessary
since we explicitly install pyopencl after the deps are installed.