### PR TITLE
build documentation as a test target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
     - TOX_ENV=py27
     - TOX_ENV=py34-opencl
     - TOX_ENV=py27-opencl
+    - TOX_ENV=docs
 install:
     - pip install --upgrade pip
     - pip install tox coveralls

--- a/tests/docs-requirements.txt
+++ b/tests/docs-requirements.txt
@@ -1,0 +1,5 @@
+# Extra requirements for building documentation
+docutils
+ipython
+matplotlib
+sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,12 @@
 [tox]
-envlist=py{27,34}{,-opencl}
+envlist=py{27,34}{,-opencl},docs
+
+[testenv:docs]
+deps=
+    {[testenv]deps}
+    -rtests/docs-requirements.txt
+commands=
+    python setup.py build_sphinx
 
 [testenv]
 deps=


### PR DESCRIPTION
The tox refactor removed the building of documentation from the test suite. Re-instate it.