### PR TITLE
Fix usage of unsafe inplace casting.

### DIFF
--- a/tests/test_xfm3.py
+++ b/tests/test_xfm3.py
@@ -14,8 +14,8 @@ def setup():
     grid = slice(-(GRID_SIZE>>1), (GRID_SIZE>>1))
     X, Y, Z = np.mgrid[grid,grid,grid]
 
-    Y *= 1.2
-    Z *= 1.4
+    Y = Y * 1.2
+    Z = Z * 1.4
 
     r = np.sqrt(X*X + Y*Y + Z*Z)
     ellipsoid = np.where(r <= SPHERE_RAD, 1.0, 0.0).astype(np.float64)


### PR DESCRIPTION
The test suite currently fails with the following error:
```
======================================================================
ERROR: test suite for <module 'tests.testxfm3' from '/build/python-dtcwt-0.10.1+dfsg1/tests/testxfm3.py'>
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/nose/suite.py", line 209, in run
    self.setUp()
  File "/usr/lib/python2.7/dist-packages/nose/suite.py", line 292, in setUp
    self.setupContext(ancestor)
  File "/usr/lib/python2.7/dist-packages/nose/suite.py", line 315, in setupContext
    try_run(context, names)
  File "/usr/lib/python2.7/dist-packages/nose/util.py", line 471, in try_run
    return func()
  File "/build/python-dtcwt-0.10.1+dfsg1/tests/testxfm3.py", line 19, in setup
    Y *= 1.2
TypeError: Cannot cast ufunc multiply output from dtype('float64') to dtype('int64') with casting rule 'same_kind'
```
due to an inplace operation requiring a cast. These now systematically throw an error for recent version of Numpy.

This patch drops usage of inplace operations.