### PR TITLE
Fix builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
+dist: trusty
+sudo: required
 language: python
 cache:
     - apt
 before_install:
+    - sudo apt-get install -y software-properties-common
+    - sudo add-apt-repository -y "deb http://us.archive.ubuntu.com/ubuntu/ trusty universe multiverse restricted"
     - sudo apt-get update -qq
-    - sudo apt-get install -y fglrx opencl-headers
+    - sudo apt-get install -y opencl-headers fglrx
 env:
     - TOX_ENV=py34
     - TOX_ENV=py27


### PR DESCRIPTION
The Travis images no-longer include restricted in the base VM image. Take the
opportunity to move over to trusty VMs.