### PR TITLE
Update call to py.test --cov

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,4 +15,4 @@ commands=
     # We can't list these in deps since pyopencl moans if numpy is not
     # fully installed at pip-install time.
     py{27,34}-opencl: pip install -rtests/opencl-requirements.txt
-    py.test --cov={envsitepackagesdir}/dtcwt --cov-report=term {posargs}
+    py.test --cov=dtcwt/ --cov-report=term {posargs}


### PR DESCRIPTION
Previously the coverage was run explicitly on the env site packaged directory.
This is unnecessary and somewhat counter-productive when it comes to tracking
the coverage via coveralls.