### PR TITLE
tox: user any python3 rather than specifying python3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ before_install:
     - sudo apt-get update -qq
     - sudo apt-get install -y opencl-headers fglrx
 env:
-    - TOX_ENV=py34
+    - TOX_ENV=py3
     - TOX_ENV=py27
-    - TOX_ENV=py34-opencl
+    - TOX_ENV=py3-opencl
     - TOX_ENV=py27-opencl
     - TOX_ENV=docs
 install:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py{27,34}{,-opencl},docs
+envlist=py{27,3}{,-opencl},docs
 
 [testenv:docs]
 deps=
@@ -8,11 +8,14 @@ deps=
 commands=
     python setup.py build_sphinx
 
+[testenv:python3]
+basepython=python3
+
 [testenv]
 deps=
     -rtests/requirements.txt
 commands=
     # We can't list these in deps since pyopencl moans if numpy is not
     # fully installed at pip-install time.
-    py{27,34}-opencl: pip install -rtests/opencl-requirements.txt
+    py{27,3}-opencl: pip install -rtests/opencl-requirements.txt
     py.test --cov=dtcwt/ --cov-report=term {posargs}


### PR DESCRIPTION
More modern developer machines likely have a later version of Python. We use
Travis to check specifically for Python 3.4 but in order to make it easier to
add travis builds to check later versions, modify tox to use whatever "python3"
is in the environment.