### PR TITLE
temporarily disable OpenCL tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ before_install:
 env:
     - TOX_ENV=py3
     - TOX_ENV=py27
-    - TOX_ENV=py3-opencl
-    - TOX_ENV=py27-opencl
     - TOX_ENV=docs
 install:
     - pip install --upgrade pip


### PR DESCRIPTION
The Travis OpenCL checks are failing because installing a working OpenCL
installation on Travis is problematic. Disable the OpenCL tests for the
moment.