### PR TITLE
fix:deprecated numpy type

### DIFF
--- a/dtcwt/numpy/lowlevel.py
+++ b/dtcwt/numpy/lowlevel.py
@@ -71,7 +71,7 @@ def colfilter(X, h):
 
     # Symmetrically extend with repeat of end samples.
     # Use 'reflect' so r < m2 works OK.
-    xe = reflect(np.arange(-m2, r+m2, dtype=np.int), -0.5, r-0.5)
+    xe = reflect(np.arange(-m2, r+m2, dtype=np.int64), -0.5, r-0.5)
 
     # Perform filtering on the columns of the extended matrix X(xe,:), keeping
     # only the 'valid' output samples, so Y is the same size as X if m is odd.
@@ -206,7 +206,7 @@ def colifilt(X, ha, hb):
         # m/2 is even, so set up t to start on d samples.
         # Set up vector for symmetric extension of X with repeated end samples.
         # Use 'reflect' so r < m2 works OK.
-        xe = reflect(np.arange(-m2, r+m2, dtype=np.int), -0.5, r-0.5)
+        xe = reflect(np.arange(-m2, r+m2, dtype=np.int64), -0.5, r-0.5)
 
         t = np.arange(3, r+m, 2)
         if np.sum(ha*hb) > 0:
@@ -233,7 +233,7 @@ def colifilt(X, ha, hb):
         # m/2 is odd, so set up t to start on b samples.
         # Set up vector for symmetric extension of X with repeated end samples.
         # Use 'reflect' so r < m2 works OK.
-        xe = reflect(np.arange(-m2, r+m2, dtype=np.int), -0.5, r-0.5)
+        xe = reflect(np.arange(-m2, r+m2, dtype=np.int64), -0.5, r-0.5)
 
         t = np.arange(2, r+m-1, 2)
         if np.sum(ha*hb) > 0:

--- a/dtcwt/sampling.py
+++ b/dtcwt/sampling.py
@@ -35,8 +35,8 @@ DTHETA_DY_2D = np.array((_W0, _W0, _W1, -_W1, -_W0, -_W0))
 
 def _sample_clipped(im, xs, ys):
     """Truncated and symmetric sampling."""
-    sym_xs = reflect(xs, -0.5, im.shape[1]-0.5).astype(np.int)
-    sym_ys = reflect(ys, -0.5, im.shape[0]-0.5).astype(np.int)
+    sym_xs = reflect(xs, -0.5, im.shape[1]-0.5).astype(np.int64)
+    sym_ys = reflect(ys, -0.5, im.shape[0]-0.5).astype(np.int64)
     return im[sym_ys, sym_xs, ...]
 
 def _sample_nearest(im, xs, ys):
@@ -328,7 +328,7 @@ def _upsample_columns(X, method=None):
     
     # Convolve
     for di, l_a, l_b in zip(sample_offsets, l_as, l_bs):
-        columns = reflect(int_columns + di, -0.5, M-0.5).astype(np.int)
+        columns = reflect(int_columns + di, -0.5, M-0.5).astype(np.int64)
         
         output[:,0::2,...] += l_a * X[:,columns,...]
         output[:,1::2,...] += l_b * X[:,columns,...]

--- a/tests/test_xfm3.py
+++ b/tests/test_xfm3.py
@@ -123,7 +123,7 @@ def test_simple_level_4_recon_ext_mode_4():
 def test_integer_input():
     # Check that an integer input is correctly coerced into a floating point
     # array
-    Yl, Yh = dtwavexfm3(np.ones((4,4,4), dtype=np.int))
+    Yl, Yh = dtwavexfm3(np.ones((4,4,4), dtype=np.int64))
     assert np.any(Yl != 0)
 
 def test_integer_perfect_recon():


### PR DESCRIPTION
## Stacktrace motivating this PR
I experienced the following issue while using `dtcwt.Transform1d.forward`

```
  File "/home/zar3bski/Documents/Code/data/wavaetro/wavaestro/loader.py", line 29, in load_initial_dataset
    vecs_t = transform.forward(signal, nlevels=5)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/zar3bski/.cache/pypoetry/virtualenvs/wavaetro--xUrs-Fb-py3.11/lib/python3.11/site-packages/dtcwt/numpy/transform1d.py", line 86, in forward
    Hi = colfilter(X, h1o)
         ^^^^^^^^^^^^^^^^^
  File "/home/zar3bski/.cache/pypoetry/virtualenvs/wavaetro--xUrs-Fb-py3.11/lib/python3.11/site-packages/dtcwt/numpy/lowlevel.py", line 74, in colfilter
    xe = reflect(np.arange(-m2, r+m2, dtype=np.int), -0.5, r-0.5)
                                            ^^^^^^
  File "/home/zar3bski/.cache/pypoetry/virtualenvs/wavaetro--xUrs-Fb-py3.11/lib/python3.11/site-packages/numpy/__init__.py", line 313, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'int'.
`np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. Did you mean: 'inf'?
```

## Environment

* dtcwt 0.12.0
* numpy 1.25.0
* Python 3.11.2

## Precision required?

I went with **int64**, not sure whether this is an overkill for the current need