### PR TITLE
Update nose-style test for pytest 8 support

### DIFF
--- a/tests/test_againstmatlab.py
+++ b/tests/test_againstmatlab.py
@@ -49,7 +49,7 @@ def assert_almost_equal_to_summary_cube(a, summary, *args, **kwargs):
 def assert_percentile_almost_equal_to_summary_cube(a, summary, *args, **kwargs):
     assert_percentile_almost_equal(summarise_cube(a), summary, *args, **kwargs)
 
-def setup():
+def setup_module():
     global mandrill
     mandrill = datasets.mandrill()
 

--- a/tests/test_coldfilt.py
+++ b/tests/test_coldfilt.py
@@ -7,7 +7,7 @@ from pytest import raises
 
 import tests.datasets as datasets
 
-def setup():
+def setup_module():
     global mandrill
     mandrill = datasets.mandrill()
 

--- a/tests/test_colfilter.py
+++ b/tests/test_colfilter.py
@@ -6,7 +6,7 @@ from dtcwt.numpy.lowlevel import colfilter
 
 import tests.datasets as datasets
 
-def setup():
+def setup_module():
     global mandrill
     mandrill = datasets.mandrill()
 

--- a/tests/test_colifilt.py
+++ b/tests/test_colifilt.py
@@ -7,7 +7,7 @@ from pytest import raises
 
 import tests.datasets as datasets
 
-def setup():
+def setup_module():
     global mandrill
     mandrill = datasets.mandrill()
 

--- a/tests/test_ifm2.py
+++ b/tests/test_ifm2.py
@@ -7,7 +7,7 @@ import tests.datasets as datasets
 
 TOLERANCE = 1e-12
 
-def setup():
+def setup_module():
     global mandrill, mandrill_crop
     mandrill = datasets.mandrill().astype(np.float64)
     mandrill_crop = mandrill[:233, :301]

--- a/tests/test_openclcoldfilt.py
+++ b/tests/test_openclcoldfilt.py
@@ -10,7 +10,7 @@ from pytest import raises
 from .util import assert_almost_equal, skip_if_no_cl
 import tests.datasets as datasets
 
-def setup():
+def setup_module():
     global mandrill
     mandrill = datasets.mandrill()
 

--- a/tests/test_openclcolfilter.py
+++ b/tests/test_openclcolfilter.py
@@ -8,7 +8,7 @@ from dtcwt.numpy.lowlevel import colfilter as colfilter_gold
 from .util import assert_almost_equal, skip_if_no_cl
 import tests.datasets as datasets
 
-def setup():
+def setup_module():
     global mandrill
     mandrill = datasets.mandrill()
 

--- a/tests/test_openclcolifilt.py
+++ b/tests/test_openclcolifilt.py
@@ -10,7 +10,7 @@ from pytest import raises
 from .util import assert_almost_equal, skip_if_no_cl
 import tests.datasets as datasets
 
-def setup():
+def setup_module():
     global mandrill
     mandrill = datasets.mandrill()
 

--- a/tests/test_openclxfm2.py
+++ b/tests/test_openclxfm2.py
@@ -12,7 +12,7 @@ import tests.datasets as datasets
 TOLERANCE = 1e-12
 GOLD_TOLERANCE = 1e-5
 
-def setup():
+def setup_module():
     global mandrill
     mandrill = datasets.mandrill()
 

--- a/tests/test_reflect.py
+++ b/tests/test_reflect.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from dtcwt.utils import reflect
 
-def setup():
+def setup_module():
     global ramp, reflected
 
     # Create a simple linear ramp and reflect it

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -8,7 +8,7 @@ from dtcwt.registration import *
 
 import tests.datasets as datasets
 
-def setup():
+def setup_module():
     global f1, f2
     f1, f2 = datasets.regframes('traffic')
 

--- a/tests/test_tfTransform1d.py
+++ b/tests/test_tfTransform1d.py
@@ -18,7 +18,7 @@ TOLERANCE = 1e-6
 
 
 @skip_if_no_tf
-def setup():
+def setup_module():
     global mandrill, in_p, pyramid_ops
     global tf, Transform1d, dtwavexfm2, dtwaveifm2, Pyramid_tf
     global np_dtypes, tf_dtypes, stats

--- a/tests/test_tfTransform2d.py
+++ b/tests/test_tfTransform2d.py
@@ -18,7 +18,7 @@ PRECISION_DECIMAL = 5
 
 
 @skip_if_no_tf
-def setup():
+def setup_module():
     # Import some tf only dependencies
     global mandrill, Transform2d, Pyramid
     global tf, np_dtypes, tf_dtypes, dtwavexfm2, dtwaveifm2

--- a/tests/test_tfinputshapes.py
+++ b/tests/test_tfinputshapes.py
@@ -12,7 +12,7 @@ PRECISION_DECIMAL = 5
 
 
 @skip_if_no_tf
-def setup():
+def setup_module():
     global tf
     tf = import_module('tensorflow')
     dtcwt.push_backend('tf')

--- a/tests/test_xfm2.py
+++ b/tests/test_xfm2.py
@@ -8,7 +8,7 @@ import tests.datasets as datasets
 
 TOLERANCE = 1e-12
 
-def setup():
+def setup_module():
     global mandrill
     mandrill = datasets.mandrill()
 

--- a/tests/test_xfm3.py
+++ b/tests/test_xfm3.py
@@ -8,7 +8,7 @@ GRID_SIZE=32
 SPHERE_RAD=0.4 * GRID_SIZE
 TOLERANCE = 1e-12
 
-def setup():
+def setup_module():
     global ellipsoid
 
     grid = slice(-(GRID_SIZE>>1), (GRID_SIZE>>1))


### PR DESCRIPTION
Pytest 8 dropped support for nose style tests, which rely on module level functions named "setup". These tests can be migrated to pytest style tests by renaming the setup functions to "setup_module".